### PR TITLE
Extending setup script to other linux builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The h3-indexer contains 3 stages, and users can [provide command line arguments]
 - YAML & JSON-based configuration supported
 
 ## Developer Setup
-The developer setup is currently compatible with ARM64 only (not compatible with x86_64).
+Developer setup is currently supported only on Linux ARM64 machines (not on x86_64 or macOS).
 
 ### Versions:
 This tool requires the following versions:

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ python
 >> import pyspark
 ```
 
+You can get the path of your python interpreter for the `.env` file environment variables (`PYTHONPATH`, `PYSPARK_PYTHON`, `PYSPARK_DRIVER_PYTHON`) by running:
+```
+which python
+```
+
 ### AWS S3 & AWS Glue Catalog
 
 You'll need to have proper credentials and permissions set up to access the files in the S3 bucket or the tables in the AWS Glue Catalog that are included in your config.

--- a/configs/sample_job.yaml
+++ b/configs/sample_job.yaml
@@ -27,7 +27,7 @@ inputs:
     type: "vector"
     s3_path: "my-bucket/data/my_polygons.parquet"
     unique_id: "id"
-    geometry_type: "LINE"
+    geometry_type: "POLYGON"
     geometry_column_name: "geometry"
     method: "PCT_AREA"
     input_columns:

--- a/scripts/env_setup.sh
+++ b/scripts/env_setup.sh
@@ -27,8 +27,17 @@ export M2_HOME=$H3/apache-maven-3.6.0
 export PATH=$M2_HOME/bin:$PATH
 
 # install Java
-sudo yum install java-1.8.0-openjdk
-JAVAPATH=$(ls -d /usr/lib/jvm/java-1.8.0-openjdk-1.8.0*)
+if command -v yum >/dev/null 2>&1; then
+  sudo yum install -y java-1.8.0-openjdk
+  JAVAPATH=$(ls -d /usr/lib/jvm/java-1.8.0-openjdk-1.8.0*)
+elif command -v apt-get >/dev/null 2>&1; then
+  sudo apt-get update
+  sudo apt-get install -y openjdk-8-jdk
+  JAVAPATH=$(ls -d /usr/lib/jvm/java-8-openjdk-* | head -n 1)
+else
+  echo "Error installing Java 8."
+  exit 1
+fi
 
 # setup aws-glue-libs
 cd $H3/aws-glue-libs


### PR DESCRIPTION
# Pull Request

## Description
- Extending setup script to other linux builds. Essentially, using an if/then statement around `yum` to fallback to `apt-get`.
- Clarified the develop instructions currently supporting Linux ARM64 builds and how to add Python env variables.
- Fixed a typo in the sample_job.yaml config.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Setup was tested on am Ubuntu Linux virtual machine with success.

- [X] Manual testing completed end-to-end with a sample config

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation